### PR TITLE
Clean up package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "4"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# dc-metro-echo [![Build Status](https://travis-ci.org/pmyers88/dc-metro-echo.svg?branch=master)](https://travis-ci.org/pmyers88/dc-metro-echo)
+# dc-metro-echo
 Amazon Echo skill for the Washington D.C. Metro
+
+- [Getting Started](#getting-started)
+- [Feature Requests](#feature-requests)
+- [Contributing](#Contributing)
+    - [Assigning Issues](#assigning-issues)
+    - [Fork](#fork)
+    - [Which branch?](#which-branch?)
+    - [Testing](#testing)
+    - [Pull Request](#pull-request)
+
+## Getting Started
+
+dc-metro-echo is not available publicly in the Echo App Store. In order to use it, you must create an Amazon
+ developer account.
+
+## Feature Requests
+
+If you would like to see a feature added, please file an issue [here](https://github.com/pmyers88/dc-metro-echo/issues),
+ it is on our radar. Add the <span style="background-color:#84b6eb">enhancement</span> label to it.
+
+If you would like to work on implementing a feature you have requested, see the [Contributing](#contributing) section. 
+
+## Contributing
+
+This project is open for anyone to contribute. Follow the steps below to do so.
+
+### Assigning Issues
+
+If an issue is currently unassigned, feel free to assign it to yourself and begin work on it.
+
+### Fork
+
+Fork the project [on GitHub](https://github.com/pmyers88/dc-metro-echo) and check out your
+copy locally.
+
+```text
+$ git clone git@github.com:username/dc-metro-echo.git
+$ cd dc-metro-echo
+$ git remote add upstream git://github.com/pmyers88/dc-metro-echo.git
+```
+
+### Which branch?
+
+Feature branches for bug fixes or new features should be created from the lastest `upstream/master` branch.
+
+### Testing
+
+We don't have any testing strategy right now.
+
+### Pull Request
+
+Please reference any issues you are addressing in your PR.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # dc-metro-echo
+
 Amazon Echo skill for the Washington D.C. Metro
 
 - [Getting Started](#getting-started)
@@ -20,7 +21,7 @@ dc-metro-echo is not available publicly in the Echo App Store. In order to use i
 If you would like to see a feature added, please file an issue [here](https://github.com/pmyers88/dc-metro-echo/issues),
  it is on our radar. Add the <span style="background-color:#84b6eb">enhancement</span> label to it.
 
-If you would like to work on implementing a feature you have requested, see the [Contributing](#contributing) section. 
+If you would like to work on implementing a feature you have requested, see the [Contributing](#contributing) section.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # dc-metro-echo
-Echo app to tell a user when the next train is arriving at a given metro station.
+Amazon Echo skill for the Washington D.C. Metro

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# dc-metro-echo
+# dc-metro-echo [![Build Status](https://travis-ci.org/pmyers88/dc-metro-echo.svg?branch=master)](https://travis-ci.org/pmyers88/dc-metro-echo)
 Amazon Echo skill for the Washington D.C. Metro

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Amazon Echo skill for the Washington D.C. Metro
     - [Which branch?](#which-branch?)
     - [Testing](#testing)
     - [Pull Request](#pull-request)
+    - [Join Us Online](#join-us-online)
 
 ## Getting Started
 
@@ -53,3 +54,7 @@ We don't have any testing strategy right now.
 ### Pull Request
 
 Please reference any issues you are addressing in your PR.
+
+### Join Us Online
+
+[![Join the chat at https://gitter.im/pmyers88/dc-metro-echo](https://badges.gitter.im/pmyers88/dc-metro-echo.svg)](https://gitter.im/pmyers88/dc-metro-echo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/package.json
+++ b/package.json
@@ -1,24 +1,26 @@
 {
   "name": "dc-metro-echo",
   "version": "1.0.0",
-  "description": "Echo app to tell a user when the next train is arriving at a given metro station.",
-  "main": "app.js",
+  "description": "Amazon Echo skill for the Washington D.C. Metro",
+  "main": "index.js",
   "scripts": {
-    "start": "node app.js",
-    "test": "./node_modules/mocha/bin/mocha"
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",
     "url": "git@github.com:pmyers88/dc-metro-echo.git"
   },
-  "author": "Phil Myers, RJ Beers",
+  "author": "Phil Myers",
+  "contributors": [
+    "RJ Beers"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/pmyers88/dc-metro-echo/issues"
   },
   "homepage": "https://github.com/pmyers88/dc-metro-echo",
   "dependencies": {
-    "lodash": "^3.8.0",
+    "lodash": "^4.0.0",
     "request": "^2.64.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "Amazon Echo skill for the Washington D.C. Metro",
   "main": "index.js",
-  "scripts": {
-    "start": "node index.js"
-  },
   "repository": {
     "type": "git",
     "url": "git@github.com:pmyers88/dc-metro-echo.git"


### PR DESCRIPTION
 * Rephrase description for keyword searches and generalized it a bit
 * Point main at the proper file, which actually exists instead of app.js
 * Remove unused scripts
 * Refactor multiple authors into single author and contributors list
 * Migrate to latest major release of lodash

Does AWS Lambda use `npm start`? If it does not, I should remove the full scripts section.
I wasn't able to test the lodash version bump, but judging from [the changelog](https://github.com/lodash/lodash/wiki/Changelog#v400), we should be safe bumping up. 