### PR TITLE
Remove Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - "4.1.1"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# dc-metro-echo [![Build Status](https://travis-ci.org/pmyers88/dc-metro-echo.svg?branch=master)](https://travis-ci.org/pmyers88/dc-metro-echo)
+# dc-metro-echo
 Echo app to tell a user when the next train is arriving at a given metro station.


### PR DESCRIPTION
There are no tests to run right now. Remove it until we are ready to use it.

Closes #17 