### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "4"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# dc-metro-echo
+# dc-metro-echo [![Build Status](https://travis-ci.org/pmyers88/dc-metro-echo.svg?branch=master)](https://travis-ci.org/pmyers88/dc-metro-echo)
 Echo app to tell a user when the next train is arriving at a given metro station.


### PR DESCRIPTION
Without a `.travis.yml`, tests are failing. Add a properly configured `.travis.yml` to force green PRs.

Effectively reverts #21, but improves the Node version.

This is likely going to cause a merge conflict with the other open PR because it is close to the same lines of code in the README.md