### PR TITLE
Create ADVISORY_WORDS custom slot type, use it in utterances and schema

### DIFF
--- a/speechAssets/IntentSchema.json
+++ b/speechAssets/IntentSchema.json
@@ -24,7 +24,12 @@
     },
     {
       "intent": "GetServiceAdvisories",
-      "slots": []
+      "slots": [
+        {
+          "name": "Advisories",
+          "type": "ADVISORY_WORDS"
+        }
+      ]
     }
   ]
 }

--- a/speechAssets/SampleUtterances.txt
+++ b/speechAssets/SampleUtterances.txt
@@ -3,8 +3,6 @@ GetStation	when is the next train arriving at {pentagon city|station}
 GetStation	when is the next train arriving at {ballston|station}
 GetDestinationStation	{wiehle-reston east|destinationStation}
 GetDestinationStation	{new carrollton|destinationStation}
-GetServiceAdvisories advisories
-GetServiceAdvisories warnings
-GetServiceAdvisories outages
-GetServiceAdvisories delays
-GetServiceAdvisories alerts
+GetServiceAdvisories    {Advisories}
+GetServiceAdvisories    are there any {Advisories}
+GetServiceAdvisories    list {Advisories}

--- a/speechAssets/customSlotTypes/ADVISORY_WORDS
+++ b/speechAssets/customSlotTypes/ADVISORY_WORDS
@@ -1,0 +1,6 @@
+advisories
+service advisories
+warnings
+outages
+delays
+alerts


### PR DESCRIPTION
Fixes #49 

Used same directory and file naming convention as in one of the Alexa [sample projects](https://github.com/amzn/alexa-skills-kit-js/tree/master/samples/savvyConsumer/speechAssets/customSlotTypes).